### PR TITLE
Fix plugins being reloaded each time

### DIFF
--- a/yantra/manager.py
+++ b/yantra/manager.py
@@ -59,7 +59,15 @@ class PluginContainer(object):
 
     def get_plugins(self):
         """Discover all plugins of the set plugin type in the path"""
-        modules = self._get_modules()
+        # ignore __init__ as they are never registered as plugins and
+        # their inclusion in `modules` will cause `len(modules)` to
+        # never equal `len(self._plugins)`, thus reloading all plugins
+        # each time this method is called.
+        modules = [
+            module
+            for module in self._get_modules()
+            if module[0] != '__init__'
+        ]
 
         # load plugins again only if a plugin was added or removed
         if len(modules) == len(self._plugins):


### PR DESCRIPTION
- Fix plugins being reloaded each time when the path to plugins has __init__ files.
- The __init__ files will be found by `self._get_modules` but since they are not
   plugins, they will never be registered in `self._plugins`. This causes plugins to
   be reloaded each time.