### PR TITLE
Make yantra upgrade compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
 
+
 setup(
     name='yantra',
-    version='0.2',
+    version='0.3',
     description='A plugin framework',
     url='',
     author='Hanif Virani',
@@ -10,4 +11,5 @@ setup(
     packages=['yantra'],
     install_requires=[
     ],
+    python_requires='>=2.7',
 )

--- a/yantra/__init__.py
+++ b/yantra/__init__.py
@@ -1,1 +1,3 @@
-from manager import PluginManager, PluginType  # noqa
+from __future__ import absolute_import
+
+from manager import PluginManager, PluginType

--- a/yantra/__init__.py
+++ b/yantra/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-from manager import PluginManager, PluginType
+from manager import PluginManager, PluginType  # noqa


### PR DESCRIPTION
Changes:

- Python 3 uses absolute import (should we use __future__ absolute import instead?)
- Require version 2.7+
- Bump yantra version
