### PR TITLE
Update exception handling to be Python3 compatible

### DIFF
--- a/yantra/manager.py
+++ b/yantra/manager.py
@@ -4,6 +4,13 @@ import os
 
 from collections import namedtuple
 
+# For Python 2 & 3 compatibility with error strings
+# Should be removed when all codebases using yantra are
+# upgraded to Python 3
+try:
+    unicode
+except NameError:
+    unicode = str
 
 PluginType = namedtuple('PluginType', ['name', 'base_class', 'path'])
 
@@ -74,7 +81,9 @@ class PluginContainer(object):
                 # load the module and look for classes
                 module = imp.load_module(modname, fp, path, desc)
             except Exception as e:
-                error_msg = e.__class__.__name__ + ': ' + e.message
+                error_msg = "{exception}: {message}".format(
+                            exception=e.__class__.__name__,
+                            message=unicode(e))
                 self._errors[fp.name] = error_msg
                 continue
 


### PR DESCRIPTION
# Overview
Python 3 [deprecated and removed the use of Exception.message](https://github.com/charlesthk/python-mailchimp/issues/61). In `manager.py`, there's a block that catches an exception and constructs the error test using `Exception.message`.

This PR converts that call to something Python 3 compatible.

Refs #SDE-6387

# Rationale
Upgrading Yantra to be Python 3 compatible is required for [Project Creation Automation](https://securitycompass.atlassian.net/wiki/spaces/DEP/pages/323747908/Project+Creation+Automation+-+PCA), which runs on Python 3 and uses Yantra as a dependency.

# Implications
Need to discuss whether Yantra needs to maintain Python 2 compatability


